### PR TITLE
Feature/innersurfaceloops

### DIFF
--- a/SketchUpNET.Unittest/BasicTests.cs
+++ b/SketchUpNET.Unittest/BasicTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace SketchUpNET.Unittest
 {
@@ -94,6 +95,43 @@ namespace SketchUpNET.Unittest
             }
 
             Assert.IsTrue(found);
+        }
+
+        [TestMethod]
+        public void TestInnerLoop()
+        {
+
+            SketchUpNET.SketchUp skp = new SketchUpNET.SketchUp();
+            skp.Surfaces = new List<Surface>();
+            skp.Curves = new List<Curve>();
+            skp.Edges = new List<Edge>();
+            List<SketchUpNET.Vertex> Verticies = new List<SketchUpNET.Vertex>();
+
+            SketchUpNET.Loop OuterEdges = new SketchUpNET.Loop();
+            OuterEdges.Edges = new List<Edge>();
+            {
+                OuterEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(0, 0, 0), new Vertex(500, 0, 0), "Layer0"));
+                OuterEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(500, 0, 0), new Vertex(500, 500, 0), "Layer0"));
+                OuterEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(500, 500, 0), new Vertex(0, 500, 0), "Layer0"));
+                OuterEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(0, 500, 0), new Vertex(0, 0, 0), "Layer0"));
+            }
+
+            List<Loop> InnerLoops = new List<Loop>();
+            {
+                SketchUpNET.Loop InnerEdges = new SketchUpNET.Loop();
+                InnerEdges.Edges = new List<Edge>();
+                InnerEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(100, 100, 0), new Vertex(400, 100, 0), "Layer0"));
+                InnerEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(400, 100, 0), new Vertex(400, 400, 0), "Layer0"));
+                InnerEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(400, 400, 0), new Vertex(100, 400, 0), "Layer0"));
+                InnerEdges.Edges.Add(new SketchUpNET.Edge(new Vertex(100, 400, 0), new Vertex(100, 100, 0), "Layer0"));
+                InnerLoops.Add(InnerEdges);
+            }
+
+            SketchUpNET.Surface s = new SketchUpNET.Surface(OuterEdges, InnerLoops, null, 0, Verticies, null, "Layer0", null, null);
+            skp.Surfaces.Add(s);
+            
+            
+            skp.AppendToModel(@"Z:\1.skp");
         }
     }
 }

--- a/SketchUpNET.Unittest/BasicTests.cs
+++ b/SketchUpNET.Unittest/BasicTests.cs
@@ -102,6 +102,7 @@ namespace SketchUpNET.Unittest
         {
 
             SketchUpNET.SketchUp skp = new SketchUpNET.SketchUp();
+            skp.Layers = new List<Layer>() { new Layer("Layer0") };
             skp.Surfaces = new List<Surface>();
             skp.Curves = new List<Curve>();
             skp.Edges = new List<Edge>();
@@ -131,7 +132,13 @@ namespace SketchUpNET.Unittest
             skp.Surfaces.Add(s);
             
             
-            skp.AppendToModel(@"Z:\1.skp");
+            skp.WriteNewModel(@"TempModel.skp");
+            skp.LoadModel(@"TempModel.skp");
+
+            Assert.IsTrue(skp.Surfaces.Count == 1);
+            Assert.IsTrue(skp.Surfaces[0].InnerEdges.Count == 1);
+            Assert.IsTrue(skp.Surfaces[0].InnerEdges[0].Edges.Count == 4);
+            Assert.IsTrue(skp.Surfaces[0].OuterEdges.Edges.Count == 4);
         }
     }
 }

--- a/SketchUpNET/SketchUpNET.cpp
+++ b/SketchUpNET/SketchUpNET.cpp
@@ -265,40 +265,7 @@ namespace SketchUpNET
 			else
 				MoreRecentFileVersion = false;
 
-			SUModelVersion saveversion = SUModelVersion::SUModelVersion_SU2020;
-
-			switch (version)
-			{
-			case SketchUpNET::SKPVersion::V2013:
-				saveversion = SUModelVersion::SUModelVersion_SU2013;
-				break;
-			case SketchUpNET::SKPVersion::V2014:
-				saveversion = SUModelVersion::SUModelVersion_SU2014;
-				break;
-			case SketchUpNET::SKPVersion::V2015:
-				saveversion = SUModelVersion::SUModelVersion_SU2015;
-				break;
-			case SketchUpNET::SKPVersion::V2016:
-				saveversion = SUModelVersion::SUModelVersion_SU2016;
-				break;
-			case SketchUpNET::SKPVersion::V2017:
-				saveversion = SUModelVersion::SUModelVersion_SU2017;
-				break;
-			case SketchUpNET::SKPVersion::V2018:
-				saveversion = SUModelVersion::SUModelVersion_SU2018;
-				break;
-			case SketchUpNET::SKPVersion::V2019:
-				saveversion = SUModelVersion::SUModelVersion_SU2019;
-				break;
-			case SketchUpNET::SKPVersion::V2020:
-				saveversion = SUModelVersion::SUModelVersion_SU2020;
-				break;
-			case SketchUpNET::SKPVersion::V2021:
-				saveversion = SUModelVersion::SUModelVersion_SU2021;
-				break;
-			default:
-				break;
-			}
+			SUModelVersion saveversion = ToSUVersion(version);
 
 			SUModelSaveToFileWithVersion(model, Utilities::ToString(newFilename), saveversion);
 
@@ -345,10 +312,22 @@ namespace SketchUpNET
 		};
 
 		/// <summary>
-		/// Write current SketchUp Model to a new SketchUp file.
+		/// Write current SketchUp Model to a new SketchUp file using the latest version.
 		/// </summary>
 		/// <param name="filename">Path to .skp file</param>
+		/// <returns></returns>
 		bool WriteNewModel(System::String^ filename)
+		{
+			return WriteNewModel(filename, SketchUpNET::SKPVersion::V2021);
+		}
+
+		/// <summary>
+		/// Write current SketchUp Model to a new SketchUp file using a specific version.
+		/// </summary>
+		/// <param name="filename">Path to .skp file</param>
+		/// <param name="version">SketchUp version</param>
+		/// <returns></returns>
+		bool WriteNewModel(System::String^ filename, SketchUpNET::SKPVersion version)
 		{
 			SUInitialize();
 			SUModelRef model = SU_INVALID;
@@ -364,8 +343,8 @@ namespace SketchUpNET
 			SUEntitiesAddEdges(entities, Edges->Count, Edge::ListToSU(Edges));
 			SUEntitiesAddCurves(entities, Curves->Count, Curve::ListToSU(Curves));
 			
-			
-			SUModelSaveToFile(model, Utilities::ToString(filename));
+			SUModelVersion v = ToSUVersion(version);
+			SUModelSaveToFileWithVersion(model, Utilities::ToString(filename), v);
 			SUModelRelease(&model);
 			SUTerminate();
 
@@ -374,6 +353,30 @@ namespace SketchUpNET
 
 		private:
 
+			SUModelVersion ToSUVersion(SketchUpNET::SKPVersion version) {
+				switch (version) {
+				case SketchUpNET::SKPVersion::V2013:
+					return SUModelVersion::SUModelVersion_SU2013;
+				case SketchUpNET::SKPVersion::V2014:
+					return SUModelVersion::SUModelVersion_SU2014;
+				case SketchUpNET::SKPVersion::V2015:
+					return SUModelVersion::SUModelVersion_SU2015;
+				case SketchUpNET::SKPVersion::V2016:
+					return SUModelVersion::SUModelVersion_SU2016;
+				case SketchUpNET::SKPVersion::V2017:
+					return SUModelVersion::SUModelVersion_SU2017;
+				case SketchUpNET::SKPVersion::V2018:
+					return SUModelVersion::SUModelVersion_SU2018;
+				case SketchUpNET::SKPVersion::V2019:
+					return SUModelVersion::SUModelVersion_SU2019;
+				case SketchUpNET::SKPVersion::V2020:
+					return SUModelVersion::SUModelVersion_SU2020;
+				case SketchUpNET::SKPVersion::V2021:
+					return SUModelVersion::SUModelVersion_SU2021;
+				default:
+					return SUModelVersion::SUModelVersion_SU2021;
+				}
+			}
 
 			void FixRefs(Component^ comp)
 			{

--- a/SketchUpNET/Surface.cpp
+++ b/SketchUpNET/Surface.cpp
@@ -122,18 +122,30 @@ namespace SketchUpNET
 
 		SUFaceRef ToSU()
 		{
-			int count = OuterEdges->Edges->Count;
+			SUFaceRef face = SU_INVALID;
 			SULoopInputRef outer_loop = SU_INVALID;
 			SULoopInputCreate(&outer_loop);
-			SUPoint3D * points = (SUPoint3D *)malloc(*&count * sizeof(SUPoint3D));
-			for (int i = 0; i < count; ++i) {
-				SULoopInputAddVertexIndex(outer_loop, i);
-				points[i] = OuterEdges->Edges[i]->Start->ToSU();
+
+			int count = OuterEdges->Edges->Count;
+			if (count > 0) {
+				SUPoint3D* points = (SUPoint3D*)malloc(*&count * sizeof(SUPoint3D));
+				for (int i = 0; i < count; ++i) {
+					SULoopInputAddVertexIndex(outer_loop, i);
+					points[i] = OuterEdges->Edges[i]->Start->ToSU();
+				}
+				SUFaceCreate(&face, points, &outer_loop);
+			} else {
+				// Maintaining backwards compatibility for 
+				// surfaces only consisting of outer vertices
+				count = Vertices->Count;
+				SUPoint3D* points = (SUPoint3D*)malloc(*&count * sizeof(SUPoint3D));
+				for (int i = 0; i < count; ++i) {
+					SULoopInputAddVertexIndex(outer_loop, i);
+					points[i] = Vertices[i]->ToSU();
+				}
+				SUFaceCreate(&face, points, &outer_loop);
 			}
-
-			SUFaceRef face = SU_INVALID;
-			SUFaceCreate(&face, points, &outer_loop);
-
+			
 			int innner_count = InnerEdges->Count;
 			if (innner_count > 0) {
 				for (int i = 0; i < innner_count; ++i) {

--- a/SketchUpNET/Surface.cpp
+++ b/SketchUpNET/Surface.cpp
@@ -122,21 +122,32 @@ namespace SketchUpNET
 
 		SUFaceRef ToSU()
 		{
-			int count = Vertices->Count;
-
+			int count = OuterEdges->Edges->Count;
 			SULoopInputRef outer_loop = SU_INVALID;
 			SULoopInputCreate(&outer_loop);
-
 			SUPoint3D * points = (SUPoint3D *)malloc(*&count * sizeof(SUPoint3D));
-			
 			for (int i = 0; i < count; ++i) {
 				SULoopInputAddVertexIndex(outer_loop, i);
-
-				points[i] = Vertices[i]->ToSU();
+				points[i] = OuterEdges->Edges[i]->Start->ToSU();
 			}
 
 			SUFaceRef face = SU_INVALID;
 			SUFaceCreate(&face, points, &outer_loop);
+
+			int innner_count = InnerEdges->Count;
+			if (innner_count > 0) {
+				for (int i = 0; i < innner_count; ++i) {
+					SULoopInputRef inner_loop = SU_INVALID;
+					SULoopInputCreate(&inner_loop);
+					int count = InnerEdges[i]->Edges->Count;
+					SUPoint3D* points = (SUPoint3D*)malloc(*&count * sizeof(SUPoint3D));
+					for (int j = 0; j < count; ++j) {
+						SULoopInputAddVertexIndex(inner_loop, j);
+						points[j] = InnerEdges[i]->Edges[j]->Start->ToSU();
+					}
+					SUFaceAddInnerLoop(face, points, &inner_loop);
+				}
+			}		
 
 			return face;
 		}


### PR DESCRIPTION
Implementing a solution to create inner loops in surfaces while maintaining backwards compatibility with surfaces which only consist of vertices for the outer loop. And adding a file version overload to write model files.